### PR TITLE
Make sure to use only a single instance of the output channel.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,19 +1,20 @@
 'use strict';
 
-import {commands, ExtensionContext} from 'vscode';
-import {runTest, runTestDirectory} from './phpunittest';
-
-export function runFile(): void {
-	runTest();
-}
-
-export function runDir(): void {
-	runTestDirectory();
-}
+import {window, commands, ExtensionContext} from 'vscode';
+import {TestRunner} from './phpunittest';
 
 export function activate(context: ExtensionContext) {
-	context.subscriptions.push(commands.registerCommand('phpunit.Test', runFile));
-    context.subscriptions.push(commands.registerCommand('phpunit.TestDirectory', runDir));
+
+	let outputChannel = window.createOutputChannel("phpunit");
+	let PHPUnitTestRunner: TestRunner = new TestRunner(outputChannel);
+
+	context.subscriptions.push(commands.registerCommand('phpunit.Test', () => {
+		PHPUnitTestRunner.runTest();
+	}));
+
+	context.subscriptions.push(commands.registerCommand('phpunit.TestDirectory', () => {
+		PHPUnitTestRunner.runTestDirectory()
+	}));
 }
 
 // this method is called when your extension is deactivated


### PR DESCRIPTION
Current release will create a new output channel for each test that gets executed. When we run a lot of tests we end up cluttering the space. 

With this PR, I have refactored the phpunittest.ts functions into a class that takes in the output channel instance from the module activation step. The will result in reusing the same instance across the test runs. 

Here is a package of my PR that can be installed to test. 
[phpunit-1.1.0.vsix.zip](https://github.com/elonmallin/vscode-phpunit/files/1286674/phpunit-1.1.0.vsix.zip)

 