### PR TITLE
Prevent output window from stealing focus

### DIFF
--- a/src/phpunittest.ts
+++ b/src/phpunittest.ts
@@ -239,7 +239,7 @@ export class TestRunner {
                     this.channel.append(buffer.toString());
                 });
     
-                this.channel.show();
+                this.channel.show(true);
             }
         }
         else


### PR DESCRIPTION
Output window grabbing focus when running tests.