### PR TITLE
Use basename to extract class name

### DIFF
--- a/src/PhpParser/PhpParser.ts
+++ b/src/PhpParser/PhpParser.ts
@@ -1,4 +1,5 @@
 import * as fs from "fs";
+import * as path from "path";
 import * as vscode from "vscode";
 import MemberTypes from "./MemberTypes";
 
@@ -42,7 +43,7 @@ export default async function parse(filePath: string) {
   });
 
   const parsed = parsePhpToObject(phpClassAsString);
-  parsed.name = filePath.match(/.*[\/\\](\w*).php$/i)[1];
+  parsed.name = path.basename(filePath, '.php');
 
   return parsed;
 }


### PR DESCRIPTION
Hi,

First of all, thanks for this extension, I favour it from all phpunit extensions for Code!

Now, I ran into an issue when I tried to run a test from a file that contained `-` in its name. I found that you use a regular expression to extract the "class" name from the file's name which should work for the majority of tests because they will follow PSR-1 naming, but I think it's worth to allow any file name.