### PR TITLE
Add phpunit.envVars configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ This extension aims to need zero config and to be highly configurable. If you ha
     "phpunit.paths": {                      // Map paths in remote environments.
         "/local/path": "/remote/path",      // ${workspaceFolder} is replaced as in tasks.json
         "${workspaceFolder}": "/remote/app"
+    },
+    "phpunit.envVars": {                      // A list of environment variables for phpunit command's execution
+        "XDEBUG_CONFIG": "remove_enable=1",      // "key" = "value
     }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -139,6 +139,10 @@
         "phpunit.execPath": {
           "type": "string",
           "description": "DEPRECATED: Use phpunit.php and phpunit.phpunit instead."
+        },
+        "phpunit.envVars": {
+            "type": "object",
+            "title": "Set environment variables before running the phpunit command"
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,7 +59,12 @@ export function activate(context: vscode.ExtensionContext) {
             vscode.TaskScope.Workspace,
             "run",
             "phpunit",
-            new vscode.ShellExecution(taskCommand),
+            new vscode.ShellExecution(
+              taskCommand,
+              {
+                env: vscode.workspace.getConfiguration('phpunit').envVars
+              },
+            ),
             problemMatcher || "$phpunit"
           )
         ];


### PR DESCRIPTION
A very useful option to allow the environment that the phpunit command is executed in to have it's own environment variables.  I use it to customize Xdebug options.


Credit goes to
https://github.com/santigarcor/vscode-phpunit-extended/commit/4ff575d1337bdc9615a9af3f41aa2d8bd88d5802