### PR TITLE
Changed phpCodeLens to work when test directory starts with capital T

### DIFF
--- a/src/CodeLens/CodeLensFeature.ts
+++ b/src/CodeLens/CodeLensFeature.ts
@@ -36,7 +36,7 @@ function enableCodeLens(context: ExtensionContext) {
     {
       language: "php",
       scheme: "file",
-      pattern: "**/test*/**/*.php",
+      pattern: "**/[tT]est*/**/*.php",
     },
     new PhpCodeLensProvider(),
   );


### PR DESCRIPTION
Fix will make both url to be found in php code lens:

src/Bundles/ExampleBundle/Tests/ExampleTest.php
tests/Component/Health/RedisCheckerTest.php

Here is test:
https://www.digitalocean.com/community/tools/glob?comments=true&glob=%2A%2A%2F%5BtT%5Dest%2A%2F%2A%2A%2F%2A.php&matches=false&options=dot%3Atrue&tests=src%2FBundles%2FExampleBundle%2FTests%2FExampleTest.php&tests=tests%2FComponent%2FHealth%2FRedisCheckerTest.php

While for current implementation first will fail:
https://www.digitalocean.com/community/tools/glob?comments=true&glob=%2A%2A%2Ftest%2A%2F%2A%2A%2F%2A.php&matches=false&options=dot%3Atrue&tests=src%2FBundles%2FExampleBundle%2FTests%2FExampleTest.php&tests=tests%2FComponent%2FHealth%2FRedisCheckerTest.php