### PR TITLE
Fix ComposerDriver isInstalled falsy check

### DIFF
--- a/src/Drivers/ComposerDriver.ts
+++ b/src/Drivers/ComposerDriver.ts
@@ -28,9 +28,7 @@ export default class Composer implements IPhpUnitDriver {
   }
 
   public async isInstalled(): Promise<boolean> {
-    return !!(
-      (await this.phpPath()) != null && (await this.phpUnitPath()) != null
-    );
+    return !!((await this.phpPath()) && (await this.phpUnitPath()));
   }
 
   public async phpPath(): Promise<string> {


### PR DESCRIPTION
Resolves #113 

I think this just completes 40bc81a5aa1d3a437363943889326657db01a442, which made this change for the other drivers.

